### PR TITLE
feat: connect to wallet button

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -58,6 +58,11 @@
   animation: gradient-animation 4s ease infinite;
 }
 
+.connect-wallet-button:disabled {
+  cursor: default;
+  background:rgba(0, 0, 0, 0.25);
+}
+
 .submit-gif-button {
   background: -webkit-linear-gradient(left, #4e44ce, #35aee2);
   background-size: 200% 200%;
@@ -127,4 +132,9 @@
 
 .connected-container button {
   height: 50px;
+}
+
+.wallet-address-container {
+  margin-top: 10px;
+  min-height: 20px;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,6 @@
 import twitterLogo from './assets/twitter-logo.svg';
 import './App.css';
+import ConnectWallet from './ConnectWallet';
 
 // Constants
 const TWITTER_HANDLE = '_buildspace';
@@ -14,6 +15,10 @@ const App = () => {
           <p className="sub-text">
             Starter template for building a Solana/Rust project.
           </p>
+          <br />
+        </div>
+        <div className="content-container">
+          <ConnectWallet />
         </div>
         <div className="footer-container">
           <img alt="Twitter Logo" className="twitter-logo" src={twitterLogo} />

--- a/src/ConnectWallet.js
+++ b/src/ConnectWallet.js
@@ -1,0 +1,38 @@
+import { useSolanaWallet  } from "./useSolanaWallet";
+
+export default function ConnectWallet() {
+  const { walletAddress, walletType, errorMessage, connectToWalletForFirstTime } = useSolanaWallet();
+
+  let buttonText = 'Connect to wallet';
+  switch (walletType) {
+    case null:
+      buttonText = 'Checking wallet...'
+      break;
+    case 'no-wallet':
+      buttonText = 'No wallet found';
+      break;
+    default:
+      buttonText = `Connect to ${walletType}`;
+      break;
+  }
+
+  if (walletAddress) {
+    buttonText = '✅ Connected'
+  }
+
+  return (
+    <>
+    <button
+      className="cta-button connect-wallet-button"
+      onClick={connectToWalletForFirstTime}
+      disabled={walletType === 'no-wallet' || !!walletAddress}
+    >
+      {buttonText}
+    </button>
+    <br />
+    <div className="gradient-text wallet-address-container">
+        <span>{walletAddress ? `Public address: ${walletAddress}` : (errorMessage || '')}</span>
+    </div>
+    </>
+  );
+}

--- a/src/useSolanaWallet.js
+++ b/src/useSolanaWallet.js
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+
+export const useSolanaWallet = () => {
+  const [walletType, setWalletType] = useState(null);
+  const [walletAddress, setWalletAddress] = useState('');
+  const [errorMessage, setErrorMessage] = useState(null);
+
+  const connectToWallet = async ({ afterUserAuthorization }) => {
+    const { solana } = window;
+    if (!solana) {
+      setWalletType('no-wallet')
+      return;
+    }
+
+    if (solana.isPhantom) {
+      setWalletType('phantom');
+      try {
+        const authorization = await solana.connect({ onlyIfTrusted: afterUserAuthorization });
+        const address = authorization.publicKey.toString();
+        setWalletAddress(address);
+      } catch(e) {
+        setErrorMessage(e.message);
+      }
+    }
+  };
+
+  const checkIfWalletIsConnected = () => connectToWallet({ afterUserAuthorization: true });
+
+  const connectToWalletForFirstTime = () => {
+    connectToWallet({ afterUserAuthorization: false });
+  };
+
+  useEffect(() => {
+    window.addEventListener('load', checkIfWalletIsConnected)
+    return () => {
+      window.removeEventListener('load', checkIfWalletIsConnected)
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return { walletType, walletAddress, errorMessage, connectToWalletForFirstTime };
+};


### PR DESCRIPTION
### Overview

This PR adds a button to connect to the phantom wallet.

The code used to connect to the wallet is very straightforward.

The part that was tricky was that if the wallet is locked, the error caused by `solana.connect` doesn't get caught by the try/catch block because it happens within a generator.

This small issue is not solved directly. Since I cannot catch the error, I chose to not rely on setting any state after the promise. Instead I make use of `walletType` and `walletAddress`. If I have the type but not the address, the connect button will show up, even if the user already connected before.

### Screenshot

![image](https://user-images.githubusercontent.com/21973269/141360454-79f0b7ba-6303-422f-829b-4c10f5432ccb.png)

